### PR TITLE
Add -willUpdate method

### DIFF
--- a/Pod/Sources/OriginateMutableRemoteArray.m
+++ b/Pod/Sources/OriginateMutableRemoteArray.m
@@ -46,7 +46,6 @@
 - (void)setObjects:(NSArray *)objects
 {
     [self setState:OriginateRemoteArrayStateIdle error:nil];
-    [self objectsWillUpdate];
     
     if (![_objects isEqualToArray:objects]) {
         _objects = [objects mutableCopy] ?: [NSMutableArray array];
@@ -88,8 +87,6 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
-    [self objectsWillUpdate];
-    
     [self.objects addObjectsFromArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didAddObjects:)]) {
@@ -104,8 +101,6 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
-    [self objectsWillUpdate];
-    
     [self.objects removeObjectsInArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didRevertAdditionOfObjects:error:)]) {
@@ -146,8 +141,6 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
-    [self objectsWillUpdate];
-    
     [self.objects removeObjectsInArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didRemoveObjects:)]) {

--- a/Pod/Sources/OriginateMutableRemoteArray.m
+++ b/Pod/Sources/OriginateMutableRemoteArray.m
@@ -48,7 +48,9 @@
     [self setState:OriginateRemoteArrayStateIdle error:nil];
     
     if (![_objects isEqualToArray:objects]) {
+        [self willChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
         _objects = [objects mutableCopy] ?: [NSMutableArray array];
+        [self didChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     }
     
     if ([self.delegate respondsToSelector:@selector(remoteArrayDidLoad:)]) {
@@ -87,7 +89,10 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    
+    [self willChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     [self.objects addObjectsFromArray:objects];
+    [self didChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didAddObjects:)]) {
         [self.delegate remoteArray:self didAddObjects:objects];
@@ -141,7 +146,10 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    
+    [self willChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     [self.objects removeObjectsInArray:objects];
+    [self didChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didRemoveObjects:)]) {
         [self.delegate remoteArray:self didRemoveObjects:objects];

--- a/Pod/Sources/OriginateMutableRemoteArray.m
+++ b/Pod/Sources/OriginateMutableRemoteArray.m
@@ -46,6 +46,7 @@
 - (void)setObjects:(NSArray *)objects
 {
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    [self objectsWillUpdate];
     
     if (![_objects isEqualToArray:objects]) {
         _objects = [objects mutableCopy] ?: [NSMutableArray array];
@@ -87,6 +88,8 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    [self objectsWillUpdate];
+    
     [self.objects addObjectsFromArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didAddObjects:)]) {
@@ -101,6 +104,8 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    [self objectsWillUpdate];
+    
     [self.objects removeObjectsInArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didRevertAdditionOfObjects:error:)]) {
@@ -141,6 +146,8 @@
     }
     
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    [self objectsWillUpdate];
+    
     [self.objects removeObjectsInArray:objects];
     
     if ([self.delegate respondsToSelector:@selector(remoteArray:didRemoveObjects:)]) {

--- a/Pod/Sources/OriginateRemoteArray+Internal.h
+++ b/Pod/Sources/OriginateRemoteArray+Internal.h
@@ -25,7 +25,6 @@ typedef NS_ENUM(NSUInteger, OriginateRemoteArrayState) {
 @property (nonatomic, strong, readwrite) NSArray<T> *objects;
 
 #pragma mark - Methods
-- (void)objectsWillUpdate;
 - (void)setObjects:(NSArray<T> *)objects;
 - (void)setLoading;
 - (void)setError:(NSError *)error;

--- a/Pod/Sources/OriginateRemoteArray+Internal.h
+++ b/Pod/Sources/OriginateRemoteArray+Internal.h
@@ -25,6 +25,7 @@ typedef NS_ENUM(NSUInteger, OriginateRemoteArrayState) {
 @property (nonatomic, strong, readwrite) NSArray<T> *objects;
 
 #pragma mark - Methods
+- (void)objectsWillUpdate;
 - (void)setObjects:(NSArray<T> *)objects;
 - (void)setLoading;
 - (void)setError:(NSError *)error;

--- a/Pod/Sources/OriginateRemoteArray.h
+++ b/Pod/Sources/OriginateRemoteArray.h
@@ -12,6 +12,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString * const OriginateRemoteArrayObjectsKey;
+
 typedef void(^OriginateRemoteArrayLoadCompletion)(NSArray *result, NSError *error);
 typedef void(^OriginateRemoteArrayLoadHandler)(OriginateRemoteArrayLoadCompletion);
 

--- a/Pod/Sources/OriginateRemoteArray.h
+++ b/Pod/Sources/OriginateRemoteArray.h
@@ -12,8 +12,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString * const OriginateRemoteArrayObjectsKey;
-
 typedef void(^OriginateRemoteArrayLoadCompletion)(NSArray *result, NSError *error);
 typedef void(^OriginateRemoteArrayLoadHandler)(OriginateRemoteArrayLoadCompletion);
 
@@ -21,6 +19,7 @@ typedef void(^OriginateRemoteArrayLoadHandler)(OriginateRemoteArrayLoadCompletio
 
 #pragma mark - Properties
 @property (nonatomic, weak, readwrite) id<OriginateRemoteArrayDelegate> delegate;
+@property (nonatomic, copy, readonly) NSArray *allObjects;
 
 #pragma mark - Methods
 - (void)load:(OriginateRemoteArrayLoadHandler)loadHandler;
@@ -30,7 +29,6 @@ typedef void(^OriginateRemoteArrayLoadHandler)(OriginateRemoteArrayLoadCompletio
 - (T)objectAtIndex:(NSUInteger)index;
 - (T)objectAtIndexedSubscript:(NSUInteger)index;
 - (NSUInteger)indexOfObject:(T)object;
-- (NSArray *)allObjects;
 
 @end
 

--- a/Pod/Sources/OriginateRemoteArray.m
+++ b/Pod/Sources/OriginateRemoteArray.m
@@ -79,12 +79,18 @@
     return self.objects;
 }
 
+- (void)objectsWillUpdate
+{
+    // intended to be overriden by subclass
+}
+
 
 #pragma mark - OriginateRemoteArray (Transitions)
 
 - (void)setObjects:(NSArray *)objects
 {
     [self setState:OriginateRemoteArrayStateIdle error:nil];
+    [self objectsWillUpdate];
     
     if (![_objects isEqualToArray:objects]) {
         _objects = objects ?: @[];

--- a/Pod/Sources/OriginateRemoteArray.m
+++ b/Pod/Sources/OriginateRemoteArray.m
@@ -79,18 +79,12 @@
     return self.objects;
 }
 
-- (void)objectsWillUpdate
-{
-    // intended to be overriden by subclass
-}
-
 
 #pragma mark - OriginateRemoteArray (Transitions)
 
 - (void)setObjects:(NSArray *)objects
 {
     [self setState:OriginateRemoteArrayStateIdle error:nil];
-    [self objectsWillUpdate];
     
     if (![_objects isEqualToArray:objects]) {
         _objects = objects ?: @[];

--- a/Pod/Sources/OriginateRemoteArray.m
+++ b/Pod/Sources/OriginateRemoteArray.m
@@ -9,8 +9,6 @@
 #import "OriginateRemoteArray.h"
 #import "OriginateRemoteArray+Internal.h"
 
-NSString * const OriginateRemoteArrayObjectsKey = @"objects";
-
 @implementation OriginateRemoteArray
 
 #pragma mark - NSObject
@@ -89,7 +87,9 @@ NSString * const OriginateRemoteArrayObjectsKey = @"objects";
     [self setState:OriginateRemoteArrayStateIdle error:nil];
     
     if (![_objects isEqualToArray:objects]) {
+        [self willChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
         _objects = objects ?: @[];
+        [self didChangeValueForKey:NSStringFromSelector(@selector(allObjects))];
     }
     
     if ([self.delegate respondsToSelector:@selector(remoteArrayDidLoad:)]) {

--- a/Pod/Sources/OriginateRemoteArray.m
+++ b/Pod/Sources/OriginateRemoteArray.m
@@ -9,6 +9,8 @@
 #import "OriginateRemoteArray.h"
 #import "OriginateRemoteArray+Internal.h"
 
+NSString * const OriginateRemoteArrayObjectsKey = @"objects";
+
 @implementation OriginateRemoteArray
 
 #pragma mark - NSObject


### PR DESCRIPTION
@pkluz 

Subclasses can currently override `-setObjects:` to find respond to updates to the backing array -- but only when the updates are done via setObjects:. Would be useful to also have a method called before inserting or removing.

Thoughts?
